### PR TITLE
Remove security logging on spring app for maximum config similarity

### DIFF
--- a/spring-todo-app/src/main/resources/application.yaml
+++ b/spring-todo-app/src/main/resources/application.yaml
@@ -1,7 +1,3 @@
-logging.level:
-  org.springframework.security: DEBUG
-
-
 spring:
   datasource:
     url: jdbc:postgresql://localhost:5432/quarkus_test


### PR DESCRIPTION
I notice there's some logging enabled in the spring case, but not the quarkus case. I don't think it's doing much at all, but extra logging could potentially cause a performance difference. For maximum comparability of before and after the migration, I think it's best to remove it, do you agree, @cescoffier?